### PR TITLE
chore: update coverage paths in pytest configuration and VSCode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -56,11 +56,11 @@
     ],
     // モジュールをインポートするときの vscode 上でモジュールが見つからないエラー防止
     "python.analysis.extraPaths": [
-        "${workspaceFolder}/.venv/lib/python3.12/site-packages",
+        "${workspaceFolder}/.venv/lib/python3.13/site-packages",
         "${workspaceFolder}/src/"
     ],
     "python.autoComplete.extraPaths": [
-        "${workspaceFolder}/.venv/lib/python3.12/site-packages",
+        "${workspaceFolder}/.venv/lib/python3.13/site-packages",
         "${workspaceFolder}/src/"
     ],
     "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,7 +159,7 @@ format.quote-style = "double"
 "tests/**/*.py" = ["S101"]
 
 [tool.pytest.ini_options]
-addopts = "-vv --tb=short -s --cov=./tests --cov-report html"
+addopts = "-vv --tb=short -s --cov=src/concord --cov-report html"
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]


### PR DESCRIPTION
- Changed coverage source path in pyproject.toml from './tests' to 'src/concord' for accurate reporting.
- Updated Python version in .vscode/settings.json from 3.12 to 3.13 for compatibility with the virtual environment.